### PR TITLE
Modifier.sentryTag uses Modifier.Node

### DIFF
--- a/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
+++ b/sentry-compose/src/androidMain/kotlin/io/sentry/compose/SentryModifier.kt
@@ -1,8 +1,13 @@
 package io.sentry.compose
 
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.SemanticsModifierNode
+import androidx.compose.ui.platform.InspectorInfo
+import androidx.compose.ui.semantics.SemanticsConfiguration
+import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsPropertyKey
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
 
 public object SentryModifier {
 
@@ -19,11 +24,35 @@ public object SentryModifier {
     )
 
     @JvmStatic
-    public fun Modifier.sentryTag(tag: String): Modifier {
-        return semantics(
-            properties = {
-                this[SentryTag] = tag
+    public fun Modifier.sentryTag(tag: String): Modifier =
+        this then SentryTagModifierNodeElement(tag)
+
+    private data class SentryTagModifierNodeElement(val tag: String) :
+        ModifierNodeElement<SentryTagModifierNode>(), SemanticsModifier {
+
+        override val semanticsConfiguration: SemanticsConfiguration =
+            SemanticsConfiguration().also {
+                it[SentryTag] = tag
             }
-        )
+
+        override fun create(): SentryTagModifierNode = SentryTagModifierNode(tag)
+
+        override fun update(node: SentryTagModifierNode) {
+            node.tag = tag
+        }
+
+        override fun InspectorInfo.inspectableProperties() {
+            name = "sentryTag"
+            properties["tag"] = tag
+        }
+    }
+
+    private class SentryTagModifierNode(var tag: String) :
+        Modifier.Node(),
+        SemanticsModifierNode {
+
+        override fun SemanticsPropertyReceiver.applySemantics() {
+            this[SentryTag] = tag
+        }
     }
 }


### PR DESCRIPTION
## :scroll: Description

Converts `Modifier.sentryTag` to be implemented with `Modifier.Node`.


## :bulb: Motivation and Context
Currently, `Modifier.sentryTag` prevents composable skipping, due to creating a lambda within a non-`@Composable` function.

Assuming the `@Composable` annotation cannot be added (might be a breaking change if other developers have used `Modifier.sentryTag` outside of a `@Composable` context), then a `Modifier.Node` implementation will help avoid recomposition.

## :green_heart: How did you test it?
I did build a UI test for this, but was unsure how to run it.

```
package io.sentry.uitest.android

import androidx.compose.foundation.layout.Box
import androidx.compose.ui.Modifier
import androidx.compose.ui.test.SemanticsMatcher
import androidx.compose.ui.test.junit4.createComposeRule
import androidx.test.ext.junit.runners.AndroidJUnit4
import io.sentry.compose.SentryModifier.sentryTag
import org.junit.Rule
import org.junit.Test
import org.junit.runner.RunWith

@RunWith(AndroidJUnit4::class)
class SentryModifierTest : BaseUiTest() {

    @get:Rule
    val rule = createComposeRule()

    @Test
    fun sentryModifierAppliesTag() {
        rule.setContent {
            Box(Modifier.sentryTag(testSentryTag))
        }
        rule.onNode(
            SemanticsMatcher(testSentryTag) {
                it.config.find { (key, _) -> key.name == "sentryTag" }?.value == testSentryTag
            }
        )
            .assertExists()
    }
}

private const val testSentryTag = "TestSentryTag"

```

## :pencil: Checklist

- [~] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [ x No breaking change for hybrid SDKs or communicated to hybrid SDKs.


## :crystal_ball: Next steps

